### PR TITLE
Move to rubygems.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
 require "gem_publisher"
-desc "Publish gem to Gemfury"
+desc "Publish gem to RubyGems"
 task :publish_gem do |t|
-  gem = GemPublisher.publish_if_updated("govuk_mirrorer.gemspec", :gemfury, :as => "govuk")
+  gem = GemPublisher.publish_if_updated("govuk_mirrorer.gemspec", :rubygems)
   puts "Published #{gem}" if gem
 end

--- a/govuk_mirrorer.gemspec
+++ b/govuk_mirrorer.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "gem_publisher", "1.2.0"
-  spec.add_development_dependency "gemfury", "0.4.16"
 end


### PR DESCRIPTION
This gem does not need to be private.  Removes
our dependency on gemfury.
